### PR TITLE
Tweak .NET engine to make it a bit more canonical

### DIFF
--- a/benchmarks/engines.toml
+++ b/benchmarks/engines.toml
@@ -277,10 +277,10 @@
   name = "dotnet"
   cwd = "../engines/dotnet"
   [engine.version]
-    bin = "bin/Release/net7.0/main"
+    bin = "bin/Release/net8.0/main"
     args = ["version"]
   [engine.run]
-    bin = "bin/Release/net7.0/main"
+    bin = "bin/Release/net8.0/main"
     args = ["interp"]
   [[engine.dependency]]
     bin = "dotnet"
@@ -302,10 +302,10 @@
   name = "dotnet/compiled"
   cwd = "../engines/dotnet"
   [engine.version]
-    bin = "bin/Release/net7.0/main"
+    bin = "bin/Release/net8.0/main"
     args = ["version"]
   [engine.run]
-    bin = "bin/Release/net7.0/main"
+    bin = "bin/Release/net8.0/main"
     args = ["compiled"]
   [[engine.dependency]]
     bin = "dotnet"
@@ -329,10 +329,10 @@
   name = "dotnet/nobacktrack"
   cwd = "../engines/dotnet"
   [engine.version]
-    bin = "bin/Release/net7.0/main"
+    bin = "bin/Release/net8.0/main"
     args = ["version"]
   [engine.run]
-    bin = "bin/Release/net7.0/main"
+    bin = "bin/Release/net8.0/main"
     args = ["nobacktrack"]
   [[engine.dependency]]
     bin = "dotnet"

--- a/benchmarks/engines.toml
+++ b/benchmarks/engines.toml
@@ -285,7 +285,7 @@
   [[engine.dependency]]
     bin = "dotnet"
     args = ["--list-sdks"]
-    regex = '(?m)^7\.'
+    regex = '(?m)^8\.'
   [[engine.build]]
     bin = "dotnet"
     args = ["build", "-c", "Release"]
@@ -310,7 +310,7 @@
   [[engine.dependency]]
     bin = "dotnet"
     args = ["--list-sdks"]
-    regex = '(?m)^7\.'
+    regex = '(?m)^8\.'
   [[engine.build]]
     bin = "dotnet"
     args = ["build", "-c", "Release"]
@@ -337,7 +337,7 @@
   [[engine.dependency]]
     bin = "dotnet"
     args = ["--list-sdks"]
-    regex = '(?m)^7\.'
+    regex = '(?m)^8\.'
   [[engine.build]]
     bin = "dotnet"
     args = ["build", "-c", "Release"]

--- a/engines/dotnet/main.csproj
+++ b/engines/dotnet/main.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
(Thanks for the nice set of benchmarks and write-ups.)

You mentioned in the README you'd be open to some changes, so just a few suggested tweaks...

Performance:
- Upgrade to .NET 8 (a supported release candidate is available, https://dotnet.microsoft.com/download/dotnet/8.0)
- Use EnumerateMatches instead of Matches when capture groups aren't needed.
- Use Match w/ NextMatch instead of Matches when capture groups are needed.
- Use EnumerateLines to avoid materializing strings for each line when not necessary

Stylistic:
- Use switch statements/expressions instead of large cascading if/elses.
- Use and slice spans instead of `List<byte>` manipulations
- No need to explicitly use Stream.Read; it can instead copy the input stream to a memory stream and get a span to the memory stream's buffered data.
- Change comments to be structured XML comments so that they show up for consumers in IntelliSense / docs / etc.
- Use Elapsed.TotalNanoseconds instead of a custom helper
- Use Func<..> instead of custom delegates
- Use ++ instead of += 1
- Use record structs for simple POCOs