### PR TITLE
Fix RE2 build failures with Homebrew-installed Abseil

### DIFF
--- a/engines/re2/build.rs
+++ b/engines/re2/build.rs
@@ -25,6 +25,25 @@ fn main() {
     builder.cpp(true);
     builder.std("c++17");
     builder.include(&upstream);
+    
+    // Get Abseil include paths and flags before building
+    // We need to collect all the include paths from all Abseil dependencies
+    let mut seen_flags = std::collections::HashSet::new();
+    for dep in ABSEIL_DEPENDENCIES {
+        if let Ok(lib) = pkg_config::probe_library(dep) {
+            for include_path in &lib.include_paths {
+                builder.include(include_path);
+            }
+            // Also add any other flags that might be needed
+            for flag in &lib.defines {
+                let flag_str = format!("-D{}", flag.0);
+                if seen_flags.insert(flag_str.clone()) {
+                    builder.flag(&flag_str);
+                }
+            }
+        }
+    }
+    
     // Currently compiling RE2 leads to a number of unused parameter warnings.
     // I'm not quite sure why, as the parameters are clearly being used for any
     // of the warnings I investigated. Maybe it's reflective of a more general
@@ -58,9 +77,7 @@ fn main() {
     // Compile RE2 along with our binding in one go.
     builder.compile("libre2.a");
 
-    // Instruct the linker to bring in Abseil dependencies.
-    // (RE2 adopted a required dependency on Abseil as of June 2023.)
-    for dep in ABSEIL_DEPENDENCIES {
-        pkg_config::probe_library(dep).unwrap();
-    }
+    // Note: We already probed for Abseil dependencies above and added their
+    // include paths to the builder. The pkg_config::probe_library() calls
+    // also set up the necessary linker flags automatically.
 }


### PR DESCRIPTION
RE2 compilation was failing with "fatal error: 'absl/base/macros.h' file not found" even when Abseil was properly installed via Homebrew. The build script called `pkg-config` but didn't add the returned include paths to the C++ compiler.

This change extracts include directories from `pkg-config` output and adds them to the cc::Build configuration, allowing the compiler to find Abseil headers in non-standard locations like `/opt/homebrew/include`.

Testing: Successfully builds and runs all RE2 benchmarks on macOS with Homebrew-installed Abseil.

(this PR was largely written by Claude Code)

---

```
% sw_vers
ProductName:            macOS
ProductVersion:         14.7.5
BuildVersion:           23H527

% xcodebuild -version                                                            
Xcode 16.1
Build version 16B40
```